### PR TITLE
fix stage env issue on ACE

### DIFF
--- a/src/AcquiaDrupalEnvironmentDetector.php
+++ b/src/AcquiaDrupalEnvironmentDetector.php
@@ -76,7 +76,7 @@ class AcquiaDrupalEnvironmentDetector {
       $ah_env = self::getAhEnv();
     }
     // ACE staging is 'test' or 'stg'; ACSF is '01test', '02test', ...
-    return preg_match('/^\d*test$/', $ah_env) || $ah_env == 'stg';
+    return preg_match('/^\d*test$/', $ah_env) || $ah_env == 'stg' || $ah_env === 'stage';
   }
 
   /**

--- a/src/AcquiaDrupalEnvironmentDetector.php
+++ b/src/AcquiaDrupalEnvironmentDetector.php
@@ -79,7 +79,7 @@ class AcquiaDrupalEnvironmentDetector {
     if (is_null($ah_env)) {
       $ah_env = self::getAhEnv();
     }
-    // ACE staging is 'test' or 'stg' or 'stage'; ACSF is '01test', '02test', ...
+    // ACE staging is 'test', 'stg', or 'stage'; ACSF is '01test', '02test', ...
     return preg_match('/^\d*test$/', $ah_env) || $ah_env == 'stg' || $ah_env === 'stage';
   }
 

--- a/src/AcquiaDrupalEnvironmentDetector.php
+++ b/src/AcquiaDrupalEnvironmentDetector.php
@@ -75,7 +75,7 @@ class AcquiaDrupalEnvironmentDetector {
     if (is_null($ah_env)) {
       $ah_env = self::getAhEnv();
     }
-    // ACE staging is 'test' or 'stg'; ACSF is '01test', '02test', ...
+    // ACE staging is 'test' or 'stg' or 'stage'; ACSF is '01test', '02test', ...
     return preg_match('/^\d*test$/', $ah_env) || $ah_env == 'stg' || $ah_env === 'stage';
   }
 

--- a/tests/EnvironmentDetectorTest.php
+++ b/tests/EnvironmentDetectorTest.php
@@ -82,6 +82,7 @@ class EnvironmentDetectorTest extends TestCase {
       ['02dev', 'dev'],
       ['test', 'stage'],
       ['stg', 'stage'],
+      ['stage', 'stage'],
       ['01test', 'stage'],
       ['02test', 'stage'],
       ['prod', 'prod'],


### PR DESCRIPTION
Fixes # 
--------
https://github.com/acquia/drupal-environment-detector/issues/11

Motivation
----------
What problem does this solve? Why is it important? What's the context?

Acquia environment detector is being used to style toolbar based on the environment for easy detection. However it is not identifying `stage` environment properly. This PR fixes that issue.

Proposed changes
---------
Changes isAhStageEnv() function to return `TRUE` if getAhEnv() return `stage` in staging environment.

Testing steps
---------
1. Goto ACE stage environment.
2. Execute `Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector:: isAhStageEnv()`. It will return `FALSE` but expected is `TRUE`
3. Print `Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector::getAhEnv()` and it should return `stage`.
