### PR TITLE
Check for ACSF update environments also.

### DIFF
--- a/src/EnvironmentNames.php
+++ b/src/EnvironmentNames.php
@@ -19,8 +19,8 @@ class EnvironmentNames {
    *   TRUE if prod, FALSE otherwise.
    */
   public static function isAhProdEnv($ah_env) {
-    // ACE prod is 'prod'; ACSF can be '01live', '02live', ...
-    return $ah_env === 'prod' || preg_match('/^\d*live$/', $ah_env);
+    // ACE prod is 'prod'; ACSF can be '01live', '01update', '02live', '02update'...
+    return $ah_env === 'prod' || preg_match('/^\d*live$/', $ah_env) || preg_match('/^\d*update$/', $ah_env);
   }
 
   /**
@@ -37,8 +37,8 @@ class EnvironmentNames {
    *   TRUE if stage, FALSE otherwise.
    */
   public static function isAhStageEnv($ah_env) {
-    // ACE staging is 'test', 'stg', or 'stage'; ACSF is '01test', '02test', ...
-    return preg_match('/^\d*test$/', $ah_env) || $ah_env === 'stg' || $ah_env === 'stage';
+    // ACE staging is 'test', 'stg', or 'stage'; ACSF is '01test', '01testup', '02test', '02testup'...
+    return preg_match('/^\d*test$/', $ah_env) || preg_match('/^\d*testup$/', $ah_env) || $ah_env === 'stg' || $ah_env === 'stage';
   }
 
   /**
@@ -51,8 +51,8 @@ class EnvironmentNames {
    *   TRUE if dev, FALSE otherwise.
    */
   public static function isAhDevEnv($ah_env) {
-    // ACE dev is 'dev', 'dev1', ...; ACSF dev is '01dev', '02dev', ...
-    return (preg_match('/^\d*dev\d*$/', $ah_env));
+    // ACE dev is 'dev', 'dev1', ...; ACSF dev is '01dev', '01devup', '02dev', '02devup'...
+    return preg_match('/^\d*dev\d*$/', $ah_env) || preg_match('/^\d*devup$/', $ah_env);
   }
 
   /**


### PR DESCRIPTION
Motivation
----------
ACSF has update environments such as 01update (live), 01devup, 01testup, etc...

During the update process, I was seeing modules for the test environment get uninstalled unexpectedly. The only explanation I could come up with was that the split that controlled these modules was not having its status overridden to enabled on the environment.

I'm not completely aware of ACSF's underlying workings, but ultimately I would see these modules get reinstalled by the time the update process completed, but they should have never been uninstalled in the first place. I'm also not sure why the modules would get reinstalled, since the process running the update seems to have taken place entirely in the update environment.

I am using BLT 12.8.2 with the standard `drupal:update` call running off of the `config-split` strategy, which runs config import twice. The first time import runs the split modules get uninstalled, and the 2nd time it runs the split modules get installed.

Proposed changes
---------
Add pattern matching to also detect the update environments that run ACSF deployments.

Testing steps
---------

Assuming you have an ACSF application with a config split for the 01test environment (`config_split.config_split.stage`) which also has some modules included in its configuration:

1. Generate an artifact with BLT.
2. Do a "Code and databases" deployment on the test environment.
3. Allow the update to complete.
4. View the logs for a site that runs on the above-mentioned split. Check for `drush cim` log output stating the modules in the split were uninstalled.
5. Also view in the logs that the modules were re-installed during the 2nd import.