### PR TITLE
[tests] back to PHP 7.3

### DIFF
--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -39,7 +39,7 @@ jobs:
           - ISOLATED_TEST_ON_NEXT_MINOR_DEV
           - INTEGRATED_UPGRADE_TEST_TO_NEXT_MINOR_DEV
           - LOOSE_DEPRECATED_CODE_SCAN
-        php-version: [ "7.4" ]
+        php-version: [ "7.3" ]
         coveralls-enable: [ "FALSE" ]
         include:
           - orca-job: ISOLATED_TEST_ON_CURRENT


### PR DESCRIPTION
PHP 7.4 integration tests are broken in ORCA. Going back to 7.3 temporarily.