### PR TITLE
DX-5108: [acsf] Use sites.json on ephemeral storage

### DIFF
--- a/src/FilePaths.php
+++ b/src/FilePaths.php
@@ -46,7 +46,7 @@ class FilePaths {
    *   The path to sites.json.
    */
   public static function acsfSitesJson(string $ah_group, string $ah_env) {
-    return "/mnt/files/$ah_group.$ah_env/files-private/sites.json";
+    return "/var/www/site-php/$ah_group.$ah_env/multisite-config.json";
   }
 
   /**


### PR DESCRIPTION
@alanevans advised that this is the canonical and more reliable path than the sites.json on Gluster.

I confirmed that on our canary ACSF subscription these files both exist and are identical.