### PR TITLE
Replace hyphen with underscore in ahSettingsFile (#86)

### DIFF
--- a/src/FilePaths.php
+++ b/src/FilePaths.php
@@ -27,7 +27,7 @@ class FilePaths {
     }
 
     // Acquia Cloud does not support periods or hyphens in db names.
-    $site_name = str_replace(['.','-'], '_', $site_name);
+    $site_name = str_replace(['.', '-'], '_', $site_name);
 
     return "/var/www/site-php/$ah_group/$site_name-settings.inc";
   }

--- a/src/FilePaths.php
+++ b/src/FilePaths.php
@@ -28,6 +28,8 @@ class FilePaths {
 
     // Acquia Cloud does not support periods in db names.
     $site_name = str_replace('.', '_', $site_name);
+    // Acquia Cloud does not support hyphens in db names.
+    $site_name = str_replace('-', '_', $site_name);
 
     return "/var/www/site-php/$ah_group/$site_name-settings.inc";
   }

--- a/src/FilePaths.php
+++ b/src/FilePaths.php
@@ -26,10 +26,8 @@ class FilePaths {
       $site_name = $ah_group;
     }
 
-    // Acquia Cloud does not support periods in db names.
-    $site_name = str_replace('.', '_', $site_name);
-    // Acquia Cloud does not support hyphens in db names.
-    $site_name = str_replace('-', '_', $site_name);
+    // Acquia Cloud does not support periods or hyphens in db names.
+    $site_name = str_replace(['.','-'], '_', $site_name);
 
     return "/var/www/site-php/$ah_group/$site_name-settings.inc";
   }


### PR DESCRIPTION
Fixes # 
--------
#86 

Motivation
----------
Acquia Cloud does not support hyphens in db names.  FilePaths::ahSettingsFile handles periods but not hyphens.

Proposed changes
---------
Ensure FilePaths::ahSettingsFile return the correct settings file when a site_name contains a hyphen

Alternatives considered
---------
A hyphen is valid character in domain names.

Testing steps
---------
Add a multisite with a hyphen in the name to a project on Acquia Cloud using Acquia Recommended Settings.
example: childrens-school.domain.com
