### PR TITLE
POST D11 release pipeline changes

### DIFF
--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -46,30 +46,26 @@ jobs:
           - ISOLATED_TEST_ON_NEXT_MINOR_DEV
           # - INTEGRATED_UPGRADE_TEST_TO_NEXT_MINOR_DEV
           - LOOSE_DEPRECATED_CODE_SCAN
-        php-version: [ "8.1" , "8.3" ]
+        php-version: [ "8.3" ]
         coveralls-enable: [ "FALSE" ]
         orca-version: [ "^4" ]
         include:
 
           - orca-job: ISOLATED_TEST_ON_CURRENT
-            php-version: "8.1"
-            coveralls-enable: "TRUE"
-
-          - orca-job: ISOLATED_TEST_ON_CURRENT
             php-version: "8.3"
             coveralls-enable: "TRUE"
 
-          - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
-            php-version: "8.3"
+          # - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
+          #   php-version: "8.3"
 
-          - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
-            php-version: "8.3"
+          # - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
+          #   php-version: "8.3"
 
-          - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
-            php-version: "8.3"
+          # - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
+          #   php-version: "8.3"
 
-          - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
-            php-version: "8.3"
+          # - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
+          #   php-version: "8.3"
 
           - orca-job: INTEGRATED_TEST_ON_LATEST_EOL_MAJOR
             php-version: "8.0"
@@ -77,6 +73,11 @@ jobs:
             orca-version: "^3"
 
           - orca-job: INTEGRATED_TEST_ON_LATEST_EOL_MAJOR
+            php-version: "8.1"
+            coveralls-enable: "FALSE"
+            orca-version: "^4"
+
+          - orca-job: INTEGRATED_TEST_ON_OLDEST_SUPPORTED
             php-version: "8.1"
             coveralls-enable: "FALSE"
             orca-version: "^4"


### PR DESCRIPTION
PHP 8.1 should only be used to run the following jobs -
-- EOL_MAJOR
-- OLDEST_SUPPORTED
-- LATEST_LTS